### PR TITLE
Change author of sockjs-go

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/d1str0/hpfeeds v0.1.3
 	github.com/fzzy/sockjs-go v0.0.0-20131128051453-1ba9e8c64209
-	github.com/jt6211/sockjs-go v0.0.0-20160127145910-881f0c021b1f
+	github.com/jatrost/sockjs-go v0.0.0-20160127145910-881f0c021b1f
 	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5 // indirect
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect


### PR DESCRIPTION
Jason Trost changed his github username from jt6211 to jatrost. This is partially causing a failure in pwnlandia/mhn#813